### PR TITLE
Fixed mvn command in yml workflow

### DIFF
--- a/labs/lab02/README.md
+++ b/labs/lab02/README.md
@@ -130,7 +130,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Compile with Maven
-        run: mvn compile
+        run: mvn clean package
       - name: Build Docker Image
         run: docker build -t semimage .
       - name: Run image


### PR DESCRIPTION
"mvn compile" doesn't provide jar files, only classes which will always result in a failed workflow action.
Use "mvn clean package" which will generate the required jar files for the workflow to complete.
