### PR TITLE
Update jacoco version

### DIFF
--- a/labs/lab07/README.md
+++ b/labs/lab07/README.md
@@ -397,7 +397,7 @@ We need Maven to generate reports for us.  There are different plugins that can 
 <plugin>
     <groupId>org.jacoco</groupId>
     <artifactId>jacoco-maven-plugin</artifactId>
-    <version>0.8.2</version>
+    <version>0.8.12</version>
     <executions>
         <execution>
             <goals>


### PR DESCRIPTION
Jacoco plugin was causing build errors at the test stage in Maven package that resulted in an error with Maven Surefire plugin. Updating to a newer Jacoco version seems to have fixed the issue. 